### PR TITLE
fix: stripe subscriptions

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,33 +1,33 @@
-import { headers } from "next/headers"
-import Stripe from "stripe"
+import { headers } from "next/headers";
+import Stripe from "stripe";
 
-import { env } from "@/env.mjs"
-import { prisma } from "@/lib/db"
-import { stripe } from "@/lib/stripe"
+import { env } from "@/env.mjs";
+import { prisma } from "@/lib/db";
+import { stripe } from "@/lib/stripe";
 
 export async function POST(req: Request) {
-  const body = await req.text()
-  const signature = headers().get("Stripe-Signature") as string
+  const body = await req.text();
+  const signature = headers().get("Stripe-Signature") as string;
 
-  let event: Stripe.Event
+  let event: Stripe.Event;
 
   try {
     event = stripe.webhooks.constructEvent(
       body,
       signature,
-      env.STRIPE_WEBHOOK_SECRET
-    )
+      env.STRIPE_WEBHOOK_SECRET,
+    );
   } catch (error) {
-    return new Response(`Webhook Error: ${error.message}`, { status: 400 })
+    return new Response(`Webhook Error: ${error.message}`, { status: 400 });
   }
 
-  const session = event.data.object as Stripe.Checkout.Session
-
   if (event.type === "checkout.session.completed") {
+    const session = event.data.object as Stripe.Checkout.Session;
+
     // Retrieve the subscription details from Stripe.
     const subscription = await stripe.subscriptions.retrieve(
-      session.subscription as string
-    )
+      session.subscription as string,
+    );
 
     // Update the user stripe into in our database.
     // Since this is the initial subscription, we need to update
@@ -41,31 +41,37 @@ export async function POST(req: Request) {
         stripeCustomerId: subscription.customer as string,
         stripePriceId: subscription.items.data[0].price.id,
         stripeCurrentPeriodEnd: new Date(
-          subscription.current_period_end * 1000
+          subscription.current_period_end * 1000,
         ),
       },
-    })
+    });
   }
 
   if (event.type === "invoice.payment_succeeded") {
-    // Retrieve the subscription details from Stripe.
-    const subscription = await stripe.subscriptions.retrieve(
-      session.subscription as string
-    )
+    const session = event.data.object as Stripe.Invoice;
 
-    // Update the price id and set the new period end.
-    await prisma.user.update({
-      where: {
-        stripeSubscriptionId: subscription.id,
-      },
-      data: {
-        stripePriceId: subscription.items.data[0].price.id,
-        stripeCurrentPeriodEnd: new Date(
-          subscription.current_period_end * 1000
-        ),
-      },
-    })
+    // If the billing reason is not subscription_create, it means the customer has updated their subscription.
+    // If it is subscription_create, we don't need to update the subscription id and it will handle by the checkout.session.completed event.
+    if (session.billing_reason != "subscription_create") {
+      // Retrieve the subscription details from Stripe.
+      const subscription = await stripe.subscriptions.retrieve(
+        session.subscription as string,
+      );
+
+      // Update the price id and set the new period end.
+      await prisma.user.update({
+        where: {
+          stripeSubscriptionId: subscription.id,
+        },
+        data: {
+          stripePriceId: subscription.items.data[0].price.id,
+          stripeCurrentPeriodEnd: new Date(
+            subscription.current_period_end * 1000,
+          ),
+        },
+      });
+    }
   }
 
-  return new Response(null, { status: 200 })
+  return new Response(null, { status: 200 });
 }


### PR DESCRIPTION
- Event handling for "invoice.payment_succeeded" only when the session.billing_reason is different from "subscription_create". If billing_reason is equal to "subscription_create", this will be handled by the event "checkout.session.completed".