### PR TITLE
refactor(hooks): minor changes in hooks

### DIFF
--- a/hooks/use-lock-body.ts
+++ b/hooks/use-lock-body.ts
@@ -1,12 +1,13 @@
-import * as React from "react"
+import { useLayoutEffect } from "react";
 
-// @see https://usehooks.com/useLockBodyScroll.
-export function useLockBody() {
-  React.useLayoutEffect((): (() => void) => {
-    const originalStyle: string = window.getComputedStyle(
-      document.body
-    ).overflow
-    document.body.style.overflow = "hidden"
-    return () => (document.body.style.overflow = originalStyle)
-  }, [])
+export default function useLockBody() {
+  useLayoutEffect(() => {
+    const originalStyle = window.getComputedStyle(document.body).overflow;
+
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = originalStyle;
+    };
+  }, []);
 }

--- a/hooks/use-media-query.ts
+++ b/hooks/use-media-query.ts
@@ -1,13 +1,15 @@
 import { useEffect, useState } from "react";
 
+type Device = "mobile" | "sm" | "tablet" | "desktop";
+
+interface Dimension {
+  width: number;
+  height: number;
+}
+
 export function useMediaQuery() {
-  const [device, setDevice] = useState<"mobile" | "sm" | "tablet" | "desktop" | null>(
-    null,
-  );
-  const [dimensions, setDimensions] = useState<{
-    width: number;
-    height: number;
-  } | null>(null);
+  const [device, setDevice] = useState<Device | null>(null);
+  const [dimensions, setDimensions] = useState<Dimension | null>(null);
 
   useEffect(() => {
     const checkDevice = () => {

--- a/hooks/use-mounted.ts
+++ b/hooks/use-mounted.ts
@@ -1,11 +1,11 @@
-import * as React from "react"
+import { useEffect, useState } from "react";
 
 export function useMounted() {
-  const [mounted, setMounted] = React.useState(false)
+  const [mounted, setMounted] = useState(false);
 
-  React.useEffect(() => {
-    setMounted(true)
-  }, [])
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
-  return mounted
+  return mounted;
 }

--- a/hooks/use-scroll.ts
+++ b/hooks/use-scroll.ts
@@ -4,7 +4,7 @@ export function useScroll(threshold: number) {
   const [scrolled, setScrolled] = useState(false);
 
   const onScroll = useCallback(() => {
-    setScrolled(window.pageYOffset > threshold);
+    setScrolled(window.scrollY > threshold);
   }, [threshold]);
 
   useEffect(() => {


### PR DESCRIPTION
- Update use-local-storage hook to accept initValue as function and value both
- Simplified use-lock-body for better understanding
- Change the deprecated `pageYOffset` to `scrollY`
- Remove the redundant part from use-mounted
- Separate Device and Dimension type in use-media-query